### PR TITLE
fix: match correct parameter with generic type fixes #606

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -76,7 +76,7 @@ class Cache implements CallbackTypeSafeGetter {
 
 	/**
 	 * @template T
-	 * @param class-string<T> $name
+	 * @param class-string<T> $className
 	 * @return T
 	 */
 	public function getInstance(string $name, string $className, callable $callback, int $secondsValid = self::DEFAULT_SECONDS_VALID):object {


### PR DESCRIPTION
When using the `getInstance` method, IDEs were not receiving the correct return type, as the parameter name was mismatched.